### PR TITLE
v1.3.6 (2023-03-03)

### DIFF
--- a/ARAH/ARAH.psd1
+++ b/ARAH/ARAH.psd1
@@ -3,7 +3,7 @@
 	RootModule        = 'ARAH.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '1.3.5'
+	ModuleVersion     = '1.3.6'
 
 	# ID used to uniquely identify this module
 	GUID              = '5bf61bed-a3da-4550-949a-a869b8dc29c6'

--- a/ARAH/changelog.md
+++ b/ARAH/changelog.md
@@ -1,6 +1,8 @@
 ﻿# Changelog
+## 1.3.6 (2023-03-03)
+ - If using a HashTable object for the `Invoke-ARAHRequest -Body` parameter it is only converted to json if the content type matches `json`.
 ## 1.3.5 (2023-01-18)
- - Added Parameter/Property SkipCheck to the ARAGConnection class and to Invoke-ARARequest  
+ - Added Parameter/Property SkipCheck to the ARAHConnection class and to Invoke-ARAHRequest  
    Allows e.g. to skip SSL checks while performing the HTTP requests
 ## 1.1.0 (2021-02-26)
  - New: automatic generation of functions based on swagger specs

--- a/ARAH/functions/Invoke-ARAHRequest.ps1
+++ b/ARAH/functions/Invoke-ARAHRequest.ps1
@@ -119,7 +119,18 @@
     }
     If ($Body) {
         switch ($Body.GetType().name) {
-            'Hashtable' { $restAPIParameter.body = ($Body | Remove-ARAHNullFromHashtable -Json) }
+            'Hashtable' {
+                switch -Regex ($effectiveContentType) {
+                    'json' {
+                        Write-PSFMessage "Converting HashTable body param to json-string"
+                        $restAPIParameter.body = ($Body | Remove-ARAHNullFromHashtable -Json)
+                    }
+                    default {
+                        Write-PSFMessage "No special handling for HashTable type body param, passing HashTable directly to Invoke-WebRequest -Body"
+                        $restAPIParameter.body = $Body
+                    }
+                }
+            }
             'String' { $restAPIParameter.body = $Body }
             Default { Write-PSFMessage -Level Warning "Unknown Body-Type: $($Body.GetType().name)" }
         }


### PR DESCRIPTION
 - If using a HashTable object for the `Invoke-ARAHRequest -Body` parameter it is only converted to json if the content type matches `json`.